### PR TITLE
Complete problems, incl. change syntax reqs for functions that have a…

### DIFF
--- a/Functions.playground/Contents.swift
+++ b/Functions.playground/Contents.swift
@@ -8,7 +8,7 @@ sayHello()
 
 // Uncomment this line to see the error that is printed in the console.
 // (You can uncomment a line by removing the // at the beginning of the line.)
-//print(greeting)
+// print(greeting)
 
 
 func sayHelloToGarfield() {
@@ -28,10 +28,10 @@ func sayHelloToCat(catName: String) {
     print("Hello, \(catName), why do you sleep so much?")
 }
 
-sayHelloToCat("Mittens")
+sayHelloToCat(catName: "Mittens")
 
 let catFriend = "Socks"
-sayHelloToCat(catFriend)
+sayHelloToCat(catName: catFriend)
 
 // Uncomment this line to see the error that is printed in the console.
-//sayHelloToCat()
+// sayHelloToCat()


### PR DESCRIPTION
…pparently changed since the course was written

Details: It now appears that a description of an argument is required even when calling a function.

e.g. `sayHelloToCat("Mittens")` throws an error –

only `sayHelloToCat(catName: "Mittens")` is accepted by XCode as correct
